### PR TITLE
Issue 46: Rename message components to fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERBOSE ?= @
 
-VERSION = 0.8.2
+VERSION = 0.9.0
 BUILDDIR = $(PWD)/build
 
 ifneq ($(MAKECMDGOALS),clean)

--- a/language/parser.py
+++ b/language/parser.py
@@ -353,21 +353,21 @@ grammar.add_rules(
         Opt("with", List(grammar.aspect, sep=",")),
         Opt(grammar.if_condition),
     ),
-    component_type_argument=ast.ComponentTypeArgument(
-        grammar.unqualified_identifier, "=>", grammar.expression
-    ),
-    null_component_item=ast.NullComponent("null", grammar.then, ";"),
-    component_item=ast.Component(
+    type_argument=ast.TypeArgument(grammar.unqualified_identifier, "=>", grammar.expression),
+    null_message_field=ast.NullMessageField("null", grammar.then, ";"),
+    message_field=ast.MessageField(
         grammar.unqualified_identifier,
         ":",
         grammar.qualified_identifier,
-        Opt("(", List(grammar.component_type_argument, sep=","), ")"),
+        Opt("(", List(grammar.type_argument, sep=","), ")"),
         Opt("with", List(grammar.aspect, sep=",")),
         Opt(grammar.if_condition),
         List(grammar.then, empty_valid=True),
         ";",
     ),
-    component_list=ast.Components(Opt(grammar.null_component_item), List(grammar.component_item)),
+    message_field_list=ast.MessageFields(
+        Opt(grammar.null_message_field), List(grammar.message_field)
+    ),
     value_range=ast.ChecksumValueRange(grammar.expression, "..", grammar.expression),
     checksum_association=ast.ChecksumAssoc(
         grammar.unqualified_identifier,
@@ -382,7 +382,7 @@ grammar.add_rules(
     message_type_definition=Or(
         ast.MessageTypeDef(
             "message",
-            grammar.component_list,
+            grammar.message_field_list,
             "end",
             "message",
             Opt("with", grammar.checksum_aspect),

--- a/language/rflx_ast.py
+++ b/language/rflx_ast.py
@@ -389,33 +389,31 @@ class Then(RFLXNode):
     condition = Field(type=Expr)
 
 
-class ComponentTypeArgument(RFLXNode):
+class TypeArgument(RFLXNode):
 
     identifier = Field(type=UnqualifiedID)
     expression = Field(type=Expr)
 
 
-class NullComponent(RFLXNode):
+class NullMessageField(RFLXNode):
 
     then = Field(type=Then)
 
 
-class Component(RFLXNode):
-    """Message component."""
+class MessageField(RFLXNode):
 
     identifier = Field(type=UnqualifiedID)
     type_identifier = Field(type=ID)
-    type_arguments = Field(type=ComponentTypeArgument.list)
+    type_arguments = Field(type=TypeArgument.list)
     aspects = Field(type=Aspect.list)
     condition = Field(type=Expr)
     thens = Field(type=Then.list)
 
 
-class Components(RFLXNode):
-    """Message components."""
+class MessageFields(RFLXNode):
 
-    initial_component = Field(type=NullComponent)
-    components = Field(type=Component.list)
+    initial_field = Field(type=NullMessageField)
+    fields = Field(type=MessageField.list)
 
 
 @abstract
@@ -450,7 +448,7 @@ class ChecksumAspect(RFLXNode):
 
 class MessageTypeDef(AbstractMessageTypeDef):
 
-    components = Field(type=Components)
+    message_fields = Field(type=MessageFields)
     checksums = Field(type=ChecksumAspect)
 
 

--- a/tests/grammar_test.py
+++ b/tests/grammar_test.py
@@ -3474,11 +3474,11 @@ def test_session_declaration(string: str, expected: Dict[str, str]) -> None:
                 "definition": {
                     "_kind": "MessageTypeDef",
                     "checksums": None,
-                    "components": {
-                        "_kind": "Components",
-                        "components": [
+                    "message_fields": {
+                        "_kind": "MessageFields",
+                        "fields": [
                             {
-                                "_kind": "Component",
+                                "_kind": "MessageField",
                                 "aspects": [],
                                 "condition": None,
                                 "identifier": {"_kind": "UnqualifiedID", "_value": "F"},
@@ -3493,7 +3493,7 @@ def test_session_declaration(string: str, expected: Dict[str, str]) -> None:
                                 },
                                 "type_arguments": [
                                     {
-                                        "_kind": "ComponentTypeArgument",
+                                        "_kind": "TypeArgument",
                                         "expression": {
                                             "_kind": "Variable",
                                             "identifier": {
@@ -3513,7 +3513,7 @@ def test_session_declaration(string: str, expected: Dict[str, str]) -> None:
                                 ],
                             }
                         ],
-                        "initial_component": None,
+                        "initial_field": None,
                     },
                 },
                 "identifier": {"_kind": "UnqualifiedID", "_value": "T"},
@@ -3527,11 +3527,11 @@ def test_session_declaration(string: str, expected: Dict[str, str]) -> None:
                 "definition": {
                     "_kind": "MessageTypeDef",
                     "checksums": None,
-                    "components": {
-                        "_kind": "Components",
-                        "components": [
+                    "message_fields": {
+                        "_kind": "MessageFields",
+                        "fields": [
                             {
-                                "_kind": "Component",
+                                "_kind": "MessageField",
                                 "aspects": [],
                                 "condition": None,
                                 "identifier": {"_kind": "UnqualifiedID", "_value": "F"},
@@ -3547,7 +3547,7 @@ def test_session_declaration(string: str, expected: Dict[str, str]) -> None:
                                 "type_arguments": [],
                             }
                         ],
-                        "initial_component": None,
+                        "initial_field": None,
                     },
                 },
                 "identifier": {"_kind": "UnqualifiedID", "_value": "T"},

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -310,7 +310,7 @@ KEYWORD_TESTS = [
         ),
         (
             "{keyword} : {keyword};",
-            librflxlang.GrammarRule.component_item_rule,
+            librflxlang.GrammarRule.message_field_rule,
         ),
         (
             "{keyword} => (1, 30..34)",


### PR DESCRIPTION
Closes #46

The release of version 0.9.0 can wait until #11 is solved.